### PR TITLE
bug/SA-GC-9

### DIFF
--- a/Content/Main/Maps/Main/MP_Main_Persistent.umap
+++ b/Content/Main/Maps/Main/MP_Main_Persistent.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d4f121a711433ef69fe0e8a1de19c92bee2cfff3a4e2a7306d7e8efc7f5cd2c8
-size 113790
+oid sha256:f80196c2f823c7a43493bca952f595c14631863c8146ee104f3934080d28bba2
+size 113114

--- a/Content/Main/Maps/Main/Sub-Levels/MP_Main_Meshes.umap
+++ b/Content/Main/Maps/Main/Sub-Levels/MP_Main_Meshes.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3551d01704414c1967fdef4b9a96817bd7fa5afddabab217d54db04981c99cfe
-size 54407
+oid sha256:1e36e61da086586092ebcd71bfc58a64304d88d164c190a53e66afdc276f022e
+size 55765

--- a/Plugins/GameFeatures/CustomAbilities/Swinging/Source/Public/PEHookAbility.h
+++ b/Plugins/GameFeatures/CustomAbilities/Swinging/Source/Public/PEHookAbility.h
@@ -24,6 +24,11 @@ public:
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Project Elementus | Properties")
 	float HookIntensity;
 
+	/* Max intensity value of the hook movement - Set 0 to disable */
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Project Elementus | Properties",
+		meta = (ClampMin = "0", UIMin = "0"))
+	float MaxHookIntensity;
+
 private:
 	virtual void ActivateAbility(const FGameplayAbilitySpecHandle Handle,
 	                             const FGameplayAbilityActorInfo* ActorInfo,

--- a/Plugins/GameFeatures/CustomAbilities/Swinging/Source/Public/PEHookAbility_Task.h
+++ b/Plugins/GameFeatures/CustomAbilities/Swinging/Source/Public/PEHookAbility_Task.h
@@ -27,7 +27,8 @@ public:
 	static UPEHookAbility_Task* HookAbilityMovement(UGameplayAbility* OwningAbility,
 	                                                const FName& TaskInstanceName,
 	                                                const FHitResult HitResult,
-	                                                const float HookIntensity);
+	                                                const float HookIntensity,
+	                                                const float HookMaxIntensity = -1.f);
 
 	virtual void Activate() override;
 
@@ -42,6 +43,7 @@ private:
 	TWeakObjectPtr<APECharacter> HitTarget;
 
 	float Intensity;
+	float MaxIntensity;
 	bool bIsFinished;
 	FHitResult HitDataHandle;
 	FVector CurrentHookLocation;

--- a/Plugins/GameFeatures/CustomAbilities/Swinging/Source/Swinging.Build.cs
+++ b/Plugins/GameFeatures/CustomAbilities/Swinging/Source/Swinging.Build.cs
@@ -22,5 +22,10 @@ public class Swinging : ModuleRules
 			"GameplayTasks",
 			"ProjectElementus"
 		});
+
+		PrivateDependencyModuleNames.AddRange(new[]
+		{
+			"GeometryCollectionEngine"
+		});
 	}
 }


### PR DESCRIPTION
**Changelog:**

* Set hook movimentation location to use the base hitresult final location instead component bone location when the target is a geometry collection; 
* Set show bone colors to false in GC example; 
* Add new param to hook ability and movimentation task to allow clamping the max intensity.